### PR TITLE
Add run_unique_key to .global files in simulation

### DIFF
--- a/applets/fff_simulator.py
+++ b/applets/fff_simulator.py
@@ -313,7 +313,12 @@ class SimulatorRun(object):
         file_name = '.run%d.global' % self.config["run"]
         full_name = os.path.join(self.config["ramdisk"], file_name)
 
-        atomic_write(full_name, 'run_key = %s' % self.config["run_key"])
+        self.config["run_unique_key"] = '4e94e771-add6-41be-8683-c5f6a7a9ed1f' # TODO : get unic key from original run used in the simulation
+
+        body  = 'run_key = %s\n' % self.config["run_key"]
+        body += 'run_unique_key = %s\n' % self.config["run_unique_key"] # like 4e94e771-add6-41be-8683-c5f6a7a9ed1f        
+
+        atomic_write(full_name, body)
         log.info('Created hidden .global run file %s' % full_name)
 
     def create_eor(self):

--- a/applets/fff_simulator.py
+++ b/applets/fff_simulator.py
@@ -310,13 +310,16 @@ class SimulatorRun(object):
 
     def create_global_file(self):
         # Creates the hidden .run*.global run file on the ramdisk.
+        # run_unique_key value - https://github.com/cms-sw/cmssw/pull/33644#issuecomment-840511487
+        # like self.config["run_unique_key"] = '4e94e771-add6-41be-8683-c5f6a7a9ed1f'
         file_name = '.run%d.global' % self.config["run"]
         full_name = os.path.join(self.config["ramdisk"], file_name)
 
-        self.config["run_unique_key"] = '4e94e771-add6-41be-8683-c5f6a7a9ed1f' # TODO : get unic key from original run used in the simulation
+        run_unique_key = '4e94e771-add6-41be-8683-c5f6a7a9ed1f'
+        if "run_unique_key" in self.config : run_unique_key = self.config["run_unique_key"]
 
         body  = 'run_key = %s\n' % self.config["run_key"]
-        body += 'run_unique_key = %s\n' % self.config["run_unique_key"] # like 4e94e771-add6-41be-8683-c5f6a7a9ed1f        
+        body += 'run_unique_key = %s\n' % run_unique_key
 
         atomic_write(full_name, body)
         log.info('Created hidden .global run file %s' % full_name)

--- a/misc/fff_simulator_dqmtools.conf
+++ b/misc/fff_simulator_dqmtools.conf
@@ -2,6 +2,7 @@
     "source": "/fff/output/playback_files/run256936/",
     "ramdisk": "/fff/ramdisk/",
     "run_key": "pp_run",
+    "run_unique_key": "4e94e771-add6-41be-8683-c5f6a7a9ed1X",
     "lumi_timeout": 23.4,
     "lumi_to_skip": [3, 4],
     "number_of_ls": 1500,


### PR DESCRIPTION
Add dummy run_unique_key to the created .global files at the moment.

**WIP:**
- extract run_unique_key from the original run used for the simulation? check how this key is important in the cmsRun