### PR TITLE
Fix regex for arch search

### DIFF
--- a/utils/cmssw_deploy.py
+++ b/utils/cmssw_deploy.py
@@ -155,7 +155,7 @@ class ScramCache(object):
         self.scan_time = time.time()
 
     def update_scram_stuff(self):
-        arch_re = re.compile(r"slc\d_amd64_gcc\d\d\d")
+        arch_re = re.compile(r"slc\d_amd64_gcc[0-9]+")
 
         projects = []
         def parse_scram(line):

--- a/utils/makerpm.sh
+++ b/utils/makerpm.sh
@@ -11,7 +11,7 @@ cd $BUILDDIR
 
 cat > fff-dqmtools.spec <<EOF
 Name: fff-dqmtools
-Version: 1.6.2
+Version: 1.6.3
 Release: 1
 Summary: DQM tools for FFF.
 License: gpl


### PR DESCRIPTION
fff_dqmtools can't find release "/opt/offline/slc7_amd64_gcc10/cms/cmssw/CMSSW_12_3_0" because there is only 2 digits at the end of "slc7_amd64_gcc10" not 3 as usual "slc7_amd64_gcc900", this lead to the following error:

> Found 8 scram releases
> Selected release: None CMSSW_12_3_0
> Make release invoked on: fu-c2f11-15-01
> Make release args: Namespace(arch='', command='make-release', label='playback_0413', log=None, no_backup=False, no_build=True, no_restore=False, path='./', pull_requests='', repo='git@github.com:cms-sw/cmssw.git', tag='CMSSW_12_3_0', tag_blacklist='ROOT5,THREADED,ICC,CLANG,DEVEL', use_tmp=True, verbose=False)
> Make release cmdline: /opt/fff_dqmtools/utils/cmssw_deploy.py make-release --use-tmp -l playback_0413 -t CMSSW_12_3_0 --no-build
> Generated directory name: ./playback_0413_CMSSW_12_3_0
> Setting SCRAM_ARCH=None
> Traceback (most recent call last):
>   File "/opt/fff_dqmtools/utils/cmssw_deploy.py", line 657, in <module>
>     make_release(scram_cache, args)
>   File "/opt/fff_dqmtools/utils/cmssw_deploy.py", line 518, in make_release
>     os.environ["SCRAM_ARCH"] = target.arch
>   File "/usr/lib64/python2.7/os.py", line 471, in __setitem__
>     putenv(key, item)
> TypeError: must be string, not None

here we propose a changes for release regular expression, tested ad P5