### PR TITLE
add according changes for the new DQM RUBU machines

### DIFF
--- a/applets/analyze_files.py
+++ b/applets/analyze_files.py
@@ -162,7 +162,8 @@ class Analyzer(object):
 
             time.sleep(105)
 
-@fff_cluster.host_wrapper(allow = ["bu-c2f13-31-01", "bu-c2f11-09-01", "bu-c2f11-13-01"])
+#@fff_cluster.host_wrapper(allow = ["bu-c2f13-31-01", "bu-c2f11-09-01", "bu-c2f11-13-01"])
+@fff_cluster.host_wrapper(allow = ["dqmrubu-c2a06-01-01","dqmrubu-c2a06-03-01"])
 @fff_dqmtools.fork_wrapper(__name__, uid="dqmpro", gid="dqmpro")
 @fff_dqmtools.lock_wrapper
 def __run__(opts, logger, **kwargs):

--- a/applets/analyze_files_lookarea_c2a06_05_01.py
+++ b/applets/analyze_files_lookarea_c2a06_05_01.py
@@ -1,0 +1,18 @@
+import fff_dqmtools
+import fff_cluster
+import logging
+
+@fff_cluster.host_wrapper(allow = ["dqmrubu-c2a06-05-01"])
+@fff_dqmtools.fork_wrapper(__name__, uid="dqmpro", gid="dqmpro")
+@fff_dqmtools.lock_wrapper
+def __run__(opts, **kwargs):
+    import analyze_files
+    analyze_files.log = kwargs["logger"]
+
+    s = analyze_files.Analyzer(
+        top = "/fff/output/lookarea/",
+        app_tag = kwargs["name"],
+        report_directory = opts["path"],
+    )
+
+    s.run_greenlet()

--- a/applets/fff_deleter_c2a06_01_01.py
+++ b/applets/fff_deleter_c2a06_01_01.py
@@ -1,0 +1,29 @@
+import fff_dqmtools
+import fff_cluster
+import fff_deleter
+import logging
+
+@fff_cluster.host_wrapper(allow = ["dqmrubu-c2a06-01-01"])
+@fff_dqmtools.fork_wrapper(__name__)
+@fff_dqmtools.lock_wrapper
+def __run__(opts, **kwargs):
+    log = kwargs["logger"]
+
+    ramdisk = "/fff/ramdisk/"
+    tag = "fff_deleter_c2a06_01_01"
+
+    service = fff_deleter.FileDeleter(
+        top = ramdisk,
+        app_tag = tag,
+        thresholds = {
+            'rename': 60,
+            'delete': 80,
+        },
+        log = log,
+        report_directory = opts["path"],
+        fake = opts["deleter.fake"],
+    )
+    service.delay_seconds = 30
+
+    service.run_greenlet()
+

--- a/applets/fff_deleter_lookarea_c2a06_05_01.py
+++ b/applets/fff_deleter_lookarea_c2a06_05_01.py
@@ -1,0 +1,29 @@
+import fff_dqmtools
+import fff_cluster
+import fff_deleter
+import logging
+
+@fff_cluster.host_wrapper(allow = ["dqmrubu-c2a06-05-01"])
+@fff_dqmtools.fork_wrapper(__name__)
+@fff_dqmtools.lock_wrapper
+def __run__(opts, **kwargs):
+    log = kwargs["logger"]
+
+    ramdisk = "/fff/output/lookarea/"
+    tag = "fff_deleter_lookarea_c2a06_05_01"
+
+    service = fff_deleter.FileDeleter(
+        top = ramdisk,
+        app_tag = tag,
+        thresholds = {
+            'rename': 60,
+            'delete': 80,
+            'delete_folders': True,
+        },
+        log = log,
+        report_directory = opts["path"],
+        fake = opts["deleter.fake"],
+    )
+    service.delay_seconds = 15*60
+
+    service.run_greenlet()

--- a/applets/fff_deleter_minidaq_c2a06_05_01.py
+++ b/applets/fff_deleter_minidaq_c2a06_05_01.py
@@ -1,0 +1,28 @@
+import fff_dqmtools
+import fff_deleter
+import fff_cluster
+import logging
+
+@fff_cluster.host_wrapper(allow = ["dqmrubu-c2a06-05-01"])
+@fff_dqmtools.fork_wrapper(__name__)
+@fff_dqmtools.lock_wrapper
+def __run__(opts, **kwargs):
+    log = kwargs["logger"]
+
+    ramdisk = "/cmsnfsdqmminidaq/dqmminidaq/"
+    tag = "fff_deleter_minidaq_c2a06_05_01"
+
+    service = fff_deleter.FileDeleter(
+        top = ramdisk,
+        app_tag = tag,
+        thresholds = {
+            'rename': 60,
+            'delete': 80,
+            'delete_folders': True,
+        },
+        log = log,
+        report_directory = opts["path"],
+        fake = opts["deleter.fake"],
+    )
+    service.delay_seconds = 15*60
+    service.run_greenlet()

--- a/applets/fff_deleter_playback_c2a06_03_01.py
+++ b/applets/fff_deleter_playback_c2a06_03_01.py
@@ -1,0 +1,28 @@
+import fff_dqmtools
+import fff_cluster
+import fff_deleter
+import logging
+
+@fff_cluster.host_wrapper(allow = ["dqmrubu-c2a06-03-01"])
+@fff_dqmtools.fork_wrapper(__name__)
+@fff_dqmtools.lock_wrapper
+def __run__(opts, **kwargs):
+    log = kwargs["logger"]
+
+    ramdisk = "/fff/ramdisk/"
+    tag = "fff_deleter_playback_c2a06_03_01"
+
+    service = fff_deleter.FileDeleter(
+        top = ramdisk,
+        app_tag = tag,
+        thresholds = {
+            'rename': 60,
+            'delete': 80,
+        },
+        log = log,
+        report_directory = opts["path"],
+        fake = opts["deleter.fake"],
+    )
+    service.delay_seconds = 30
+
+    service.run_greenlet()

--- a/applets/fff_simulator.py
+++ b/applets/fff_simulator.py
@@ -582,7 +582,7 @@ class FFFSimulatorSocket(fff_control.Ctrl):
 
         run.control(line.strip(), write_f)
 
-@fff_cluster.host_wrapper(allow = ["bu-c2f11-13-01"])
+@fff_cluster.host_wrapper(allow = ["dqmrubu-c2a06-03-01"])
 @fff_dqmtools.fork_wrapper(__name__)
 @fff_dqmtools.lock_wrapper
 def __run__(**kwargs):

--- a/applets/fff_web.py
+++ b/applets/fff_web.py
@@ -735,12 +735,12 @@ class WebServer(bottle.Bottle):
               return json.dumps( answer )
 
             if what == "get_simulator_config" :
-              host = bottle.request.query.get('host', default="bu-c2f11-13-01")
+              host = bottle.request.query.get('host', default="dqmrubu-c2a06-03-01")
               answer = fff_cluster.get_simulator_config( self.opts, fff_cluster.get_host(), host )
               return json.dumps( answer )
 
             if what == "get_simulator_runs" :
-              host = bottle.request.query.get('host', default="bu-c2f11-13-01")
+              host = bottle.request.query.get('host', default="dqmrubu-c2a06-03-01")
               answer = fff_cluster.get_simulator_runs( self.opts, fff_cluster.get_host(), host )
               return json.dumps( answer )
 
@@ -773,7 +773,7 @@ class WebServer(bottle.Bottle):
               return json.dumps( [answer] )
 
             if what == "start_playback_run" :
-              host = bottle.request.query.get('host', default="bu-c2f11-13-01")
+              host = bottle.request.query.get('host', default="dqmrubu-c2a06-03-01")
               if( fff_cluster.get_host() != host ) :
                 url = 'http://' + host + ':' + str(self.opts["web.port"])  + '/cr/exe?' + bottle.request.urlparts.query
                 r = requests.get(url, data=bottle.request.body, headers = bottle.request.headers, timeout=60)

--- a/fff_cluster.py
+++ b/fff_cluster.py
@@ -9,9 +9,12 @@ from threading import Timer
 import json
 
 clusters = {
-  'production_c2f11': ["bu-c2f11-09-01.cms", "fu-c2f11-11-01.cms", "fu-c2f11-11-02.cms", "fu-c2f11-11-03.cms", "fu-c2f11-11-04.cms", ],
-  'playback_c2f11': ["bu-c2f11-13-01.cms", "fu-c2f11-15-01.cms", "fu-c2f11-15-02.cms", "fu-c2f11-15-03.cms", "fu-c2f11-15-04.cms", ],
-  'lookarea_c2f11': ["bu-c2f11-19-01.cms", ]
+#  'production_c2f11': ["bu-c2f11-09-01.cms", "fu-c2f11-11-01.cms", "fu-c2f11-11-02.cms", "fu-c2f11-11-03.cms", "fu-c2f11-11-04.cms", ],
+#  'playback_c2f11': ["bu-c2f11-13-01.cms", "fu-c2f11-15-01.cms", "fu-c2f11-15-02.cms", "fu-c2f11-15-03.cms", "fu-c2f11-15-04.cms", ],
+#  'lookarea_c2f11': ["bu-c2f11-19-01.cms", ]
+  'production_c2a06': ["dqmrubu-c2a06-01-01.cms", ],
+  'playback_c2a06': ["dqmrubu-c2a06-03-01.cms", ],
+  'lookarea_c2a06': ["dqmrubu-c2a06-05-01.cms", ]
 }
 
 def popen_timeout(cmd, seconds=10):

--- a/fff_dqmtools.py
+++ b/fff_dqmtools.py
@@ -394,12 +394,12 @@ if __name__ == "__main__":
     default_applets = [
         "fff_web", "fff_selftest", "fff_logcleaner", "fff_logcleaner_gzip", "fff_filemonitor",
 
-        "fff_deleter_c2f11_09_01", "fff_deleter_playback_c2f11_13_01",
-        "fff_deleter_lookarea_c2f11_19_01", "fff_deleter_minidaq_c2f11_19_01",
+        "fff_deleter_c2a06_01_01", "fff_deleter_playback_c2a06_03_01",
+        "fff_deleter_lookarea_c2a06_05_01", "fff_deleter_minidaq_c2a06_05_01",
         "fff_deleter_minidaq_cms904",
 
         "fff_simulator",
-        "analyze_files", "analyze_files_lookarea_c2f11_19_01", "analyze_releases",
+        "analyze_files", "analyze_files_lookarea_c2a06_05_01", "analyze_releases",
     ]
 
     config_web_secret = "changeme"

--- a/utils/makerpm.sh
+++ b/utils/makerpm.sh
@@ -11,7 +11,7 @@ cd $BUILDDIR
 
 cat > fff-dqmtools.spec <<EOF
 Name: fff-dqmtools
-Version: 1.7.6
+Version: 1.7.7
 Release: 1
 Summary: DQM tools for FFF.
 License: gpl


### PR DESCRIPTION
The changes modify the following
1) name of the DQM machines for production, playback and look area (subsystem), including updating the files and also adding files of fff_deleter and analyze_files in the applets directory
2) version in makerpm.sh from 1.7.6 to 1.7.7