### PR TITLE
remove new dqmfu from the production machines

### DIFF
--- a/fff_cluster.py
+++ b/fff_cluster.py
@@ -12,7 +12,7 @@ clusters = {
 #  'production_c2f11': ["bu-c2f11-09-01.cms", "fu-c2f11-11-01.cms", "fu-c2f11-11-02.cms", "fu-c2f11-11-03.cms", "fu-c2f11-11-04.cms", ],        
 #  'playback_c2f11': ["bu-c2f11-13-01.cms", "fu-c2f11-15-01.cms", "fu-c2f11-15-02.cms", "fu-c2f11-15-03.cms", "fu-c2f11-15-04.cms", ],          
 #  'lookarea_c2f11': ["bu-c2f11-19-01.cms", ]                                                                                                   
-  'production_c2a06': ["dqmrubu-c2a06-01-01.cms", "dqmfu-c2b01-45-01.cms", "dqmfu-c2b02-45-01.cms"],
+  'production_c2a06': ["dqmrubu-c2a06-01-01.cms"],
   'playback_c2a06': ["dqmrubu-c2a06-03-01.cms", "dqmfu-c2b01-45-01.cms", "dqmfu-c2b02-45-01.cms"],
   'lookarea_c2a06': ["dqmrubu-c2a06-05-01.cms"]
 }


### PR DESCRIPTION
Since we have only playback dqmfu machines, we remove the dqmfu machines from the cluster of production.