### PR TITLE
add production machines of new dqmfu and update version number

### DIFF
--- a/fff_cluster.py
+++ b/fff_cluster.py
@@ -9,10 +9,7 @@ from threading import Timer
 import json
 
 clusters = {
-#  'production_c2f11': ["bu-c2f11-09-01.cms", "fu-c2f11-11-01.cms", "fu-c2f11-11-02.cms", "fu-c2f11-11-03.cms", "fu-c2f11-11-04.cms", ],        
-#  'playback_c2f11': ["bu-c2f11-13-01.cms", "fu-c2f11-15-01.cms", "fu-c2f11-15-02.cms", "fu-c2f11-15-03.cms", "fu-c2f11-15-04.cms", ],          
-#  'lookarea_c2f11': ["bu-c2f11-19-01.cms", ]                                                                                                   
-  'production_c2a06': ["dqmrubu-c2a06-01-01.cms", "dqmfu-c2b01-45-01.cms", "dqmfu-c2b02-45-01.cms"],
+  'production_c2a06': ["dqmrubu-c2a06-01-01.cms", "dqmfu-c2b03-45-01.cms", "dqmfu-c2b04-45-01.cms"],
   'playback_c2a06': ["dqmrubu-c2a06-03-01.cms", "dqmfu-c2b01-45-01.cms", "dqmfu-c2b02-45-01.cms"],
   'lookarea_c2a06': ["dqmrubu-c2a06-05-01.cms"]
 }

--- a/utils/makerpm.sh
+++ b/utils/makerpm.sh
@@ -11,7 +11,7 @@ cd $BUILDDIR
 
 cat > fff-dqmtools.spec <<EOF
 Name: fff-dqmtools
-Version: 1.9.3
+Version: 1.9.4
 Release: 1
 Summary: DQM tools for FFF.
 License: gpl

--- a/web.static/js/app.js
+++ b/web.static/js/app.js
@@ -40,7 +40,6 @@ dqmApp.controller('NavigationCtrl', [
         /// return for web outside P5 (always via cmsweb-testbed or cmsweb frontier redirection)
         var local_token = tokens[2];
         var local = window.location.href;
-//        if( local_token.includes("bu-c2f11-13-01") ){ // hard code check of entry point
         if( local_token.includes("dqmrubu-c2a06-03-01") ){ // hard code check of entry point
           if( local.includes("cmsweb-testbed") ){
             return "https://cmsweb-testbed.cern.ch/dqm/dqm-square-origin/sync_proxy";


### PR DESCRIPTION
As the subject, adding dqmfu-c2b03-45-01 and dqmfu-c2b04-45-01  in fff_clusters.py and update version number. 

Not sure if I need to replace dqmrubu-c2a06-05-01 with a spare rubu machine. The current production version has a machine name that I don't recognize as online machines: bu-c2f13-31-01.

https://github.com/syuvivida/fff_dqmtools/blob/syu_newrubu_v2/applets/analyze_files.py#L165